### PR TITLE
adding arm64 support for darwin

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -41,8 +41,14 @@ platform() {
 }
 
 arch() {
-  [ ! "x86_64" = "$(uname -m)" ] && echo "architecture $(uname -m), is not supported" && exit 1
-  echo -n "amd64"
+  if [ "x86_64" = "$(uname -m)" ]; then
+    echo -n "amd64"
+  elif [ "arm64" = "$(uname -m)" ] && [ $(platform) = "darwin" ]; then
+    echo -n "arm64"
+  else
+    echo "platform $(uname) architecture $(uname -m), is not supported" >&2
+    exit 1
+  fi
 }
 
 install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA (404 error)
* [X] I have updated/added any relevant documentation (not required)

## Description
### What's the goal of this PR?
* To add support for arm64 calicoctl builds for Apple Silicon/M1/M2

### What changes did you make?
* updated the install to allow `arm64` for `darwin` builds
* also updated error message to send to stderr as it was getting lost and users got no feedback on install failure.

### What alternative solution should we consider, if any?
* I would suggest we add support for all calicoctl builds and/or have a supported builds page in the README

